### PR TITLE
[TRH-83] Fix Service can't send second message

### DIFF
--- a/ServiceApplication/src/ServiceManager.cpp
+++ b/ServiceApplication/src/ServiceManager.cpp
@@ -1,8 +1,7 @@
 #include "ServiceManager.hpp"
 #include "Routing.hpp"
 #include "Full_Search.hpp"
-#include <chrono>
-#include <thread>
+#include <QTimer>
 
 ServiceManager::ServiceManager(QObject* parent) : QObject(parent)
 {
@@ -16,9 +15,12 @@ ServiceManager::~ServiceManager() {}
 void ServiceManager::notifyClient(TCP::tcp_id_t clientId, Mtx::Matrix<double>& routes, double length)
 {
     m_Server.sendMessage(clientId, &routes);
-    QString len = QString::number(length);
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    m_Server.sendMessage(clientId, &len);
+
+    // TODO: сделать нормально TRH-84
+    QTimer::singleShot(10, this, [this, clientId, length]() {
+        QString len = QString::number(length);
+        m_Server.sendMessage(clientId, &len);
+    });
 }
 
 void ServiceManager::processAlgo(TCP::tcp_id_t clientId)


### PR DESCRIPTION
Пофиксил баг, что Сервис отправлял только дороги, но не отправлял значение целевой функции. Большая проблема, что между сообщениями нужно ставить задержку (хотя бы 10 миллисекунд) и я завёл на это задачку TRH-83, но пока так...

Ref: TRH-83